### PR TITLE
make hashbang less brittle by using env

### DIFF
--- a/articles/FileEditor.md
+++ b/articles/FileEditor.md
@@ -22,5 +22,5 @@ PythonAnywhere's built-in file editor allows you to edit your files with syntax 
 When you want to run your code, you can use the "Save and run" button at the top right. This uses Python 2.7 by default; if you want to use a different version, you can use what's known as a "hashbang" in the very first line of your file. You start with the characters #!, and then the path to the interpreter you want, eg:
 
     :::python
-    #!/usr/local/bin/python3.3
+    #!/usr/bin/env python3
     print("Hello, World")


### PR DESCRIPTION
Instead of the full path, if you use /usr/bin/env it will work in virtualenv's as well as non-virtualenvs.  Also, targeting a more generic version of Python 3, the default instead of 3.3, which is two revisions behind and a full revision behind what is available on PythonAnywhere.