### PR TITLE
Fix wrong code in example

### DIFF
--- a/articles/Flask.md
+++ b/articles/Flask.md
@@ -106,7 +106,7 @@ This is ok
     def home():
         # etc etc, flask app code
 
-    if __name__ = '__main__':
+    if __name__ == '__main__':
         app.run()
 
 This is not ok:


### PR DESCRIPTION
In the example code, the comparison operator `==` is mistaken  as `=` assignment operator.