### PR TITLE
Change location for Config file for Letsencrypt from /home/YOURUSERNAME/letsencrypt/config to  /home/YOURUSERNAME/dehydrated/config

### DIFF
--- a/articles/LetsEncrypt.md
+++ b/articles/LetsEncrypt.md
@@ -38,7 +38,7 @@ mapping:
 the instructions below) and then **reload your web app**
 
 We'll need to create a simple config file. Put the following (with suitable
-replacements) into a file at `/home/YOURUSERNAME/letsencrypt/config`
+replacements) into a file at `/home/YOURUSERNAME/dehydrated/config`
 
     :::bash
     WELLKNOWN=/home/YOURUSERNAME/letsencrypt/wellknown


### PR DESCRIPTION
I have followed the existing tutorial twice and failed to create a config file that works at "/home/YOURUSERNAME/letsencrypt/config". Each time I would get the same error message shown in the attachment.
capture

The configuration would only work when I created the config file at "/home/YOURUSERNAME/dehydrated/config" as per guidelines given here: https://github.com/lukas2511/dehydrated.

I think its best to change the tutorial to show this so that other users won't face the same difficulties I faced of getting errors while faithfully following the tutorial.
![capture](https://user-images.githubusercontent.com/13593285/30038967-17540242-91cb-11e7-92c5-37224036c9f8.PNG)
