### PR TITLE
make the static file section more clear

### DIFF
--- a/articles/LetsEncrypt.md
+++ b/articles/LetsEncrypt.md
@@ -40,6 +40,8 @@ column):
 
 <img alt="Let's Encrypt static files setup" src="/letsencrypt-staticfiles.png" style="border: 2px solid lightblue; max-width: 70%;">
 
+Please note that this step is mandatory even if you currently do not serve up static files in this way.
+
 If you're using our password-protection feature for your web app, you'll also need to switch that off for the duration of this procedure;
 you can turn it on again once you've got the certificate.
 


### PR DESCRIPTION
Lots of people, myself included, maybe think they can skip the static file mapping part of the tutorial because their static files section on pythonanywhere's web tab is empty.