### PR TITLE
Missing slash in API file endpoint

### DIFF
--- a/articles/API.md
+++ b/articles/API.md
@@ -101,7 +101,7 @@ connecting to the console in a browser will do that).</td><td style="width: 30%"
 
 ## Files
 
-### /api/v0/user/{username}/files/path{path}
+### /api/v0/user/{username}/files/path/{path}
 
 <table class="table table-striped">
   <tr><th>Method</th><th>Description</th><th>Parameters</th>


### PR DESCRIPTION
/api/v0/user/{username}/files/path{path}     -->     /api/v0/user/{username}/files/path/{path}