### PR TITLE
Fixed missing slash in API file endpoint path

### DIFF
--- a/articles/API.md
+++ b/articles/API.md
@@ -101,7 +101,7 @@ connecting to the console in a browser will do that).</td><td style="width: 30%"
 
 ## Files
 
-### /api/v0/user/{username}/files/path{path}
+### /api/v0/user/{username}/files/path/{path}
 
 <table class="table table-striped">
   <tr><th>Method</th><th>Description</th><th>Parameters</th>


### PR DESCRIPTION
Hi there, this is my first commit for a project which is not my own so hope this is correct - just missing a forward slash in the file endpoint path. 