### PR TITLE
Access List Replaces Whitelist

### DIFF
--- a/articles/MongoDB.md
+++ b/articles/MongoDB.md
@@ -44,22 +44,22 @@ This handles the bulk of the stuff that would otherwise be handled by Flask-PyMo
 if you were using it.
 
 
-# Whitelisting your IP address for MongoDB Atlas
+# Accesslist your IP address for MongoDB Atlas
 
 MongoDB Atlas requires you to provide the IP address of any code that is trying
 to connect to your Mongo instance; this can be a bit tricky on PythonAnywhere,
 because the precise IP address will depend on the time your code runs, and
 whether it's running in a website's code, or in a task, or in a console.
 
-The easiest, solution, though certainly not the most secure, is to whitelist the
-CIDR `0.0.0.0/0`, which is a "whitelist" containing every IP address on the Internet.
+The easiest, solution, though certainly not the most secure, is to accesslist the
+CIDR `0.0.0.0/0`, which is a "accesslist" containing every IP address on the Internet.
 
 A more secure solution is to use the MongoDB Atlas API to them about new IP
 addresses that they should allow to connect.  You can combine that with the
 [ipify service](https://www.ipify.org/), which tells you what IP address your
-code is using right now, to make your code automatically whitelist the IP it's
+code is using right now, to make your code automatically accesslist the IP it's
 running on when it starts up.  The following code (based on code provided by
-Nicolas Oteiza) will do that. You just need to
+Nicolas Oteiza and modified by Amitoz Azad) will do that. You just need to
 [install the ipify module](https://help.pythonanywhere.com/pages/InstallingNewModules/) and then use this,
 replacing the bits inside the `<>`s:
 
@@ -69,20 +69,20 @@ replacing the bits inside the `<>`s:
     from ipify import get_ip
 
     atlas_group_id = "<your group ID aka project ID -- check the Project / Settings section inside Atlas>"
-    atlas_username = "<your atlas username/email, eg. jane@example.com>"
-    atlas_api_key = "<your atlas API key>"
+    atlas_api_key_public = "<your atlas public API key>"
+    atlas_api_key_private = "<your atlas private API key>"
     ip = get_ip()
 
     resp = requests.post(
-        "https://cloud.mongodb.com/api/atlas/v1.0/groups/{atlas_group_id}/whitelist".format(atlas_group_id=atlas_group_id),
-        auth=HTTPDigestAuth(atlas_username, atlas_api_key),
+        "https://cloud.mongodb.com/api/atlas/v1.0/groups/{atlas_group_id}/accessList".format(atlas_group_id=atlas_group_id),
+        auth=HTTPDigestAuth(atlas_api_public_key, atlas_api_private_key),
         json=[{'ipAddress': ip, 'comment': 'From PythonAnywhere'}]  # the comment is optional
     )
     if resp.status_code in (200, 201):
-        print("MongoDB Atlas whitelist request successful", flush=True)
+        print("MongoDB Atlas accessList request successful", flush=True)
     else:
         print(
-            "MongoDB Atlas whitelist request problem: status code was {status_code}, content was {content}".format(
+            "MongoDB Atlas accessList request problem: status code was {status_code}, content was {content}".format(
                 status_code=resp.status_code, content=resp.content
             ),
             flush=True
@@ -93,7 +93,7 @@ If there is not a version of the ipify module that works with the version of
 Python that you are using, you can just use the REST interface to ipify. There
 is a complete example on the "Code Samples" page on the ipify web site.
 
-If there are any problems whitelisting your IP address (for example, if the
+If there are any problems accesslisting your IP address (for example, if the
 API key is wrong) then you will find the error messages in the program's output;
 for websites, it will be in the server log file (linked from the "Web" page).
 


### PR DESCRIPTION
Whitelist is deprecated and will soon (june 2021) be disabled. Check the IMPORTANT  block in yellow   [here](https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/)

The whitelist post  request as mentioned in the help page doesn't work for me and throws 401 error.

The accessList post request  works smoothly, but one has to use the public key and private key while authenticating and the **atlas username is not required.**
Check the [curl post example](https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/#example-request) on how to accessList your ip  