### PR TITLE
Clarification on EU and Global-US hostnames

### DIFF
--- a/articles/AccessingMySQLFromOutsidePythonAnywhere.md
+++ b/articles/AccessingMySQLFromOutsidePythonAnywhere.md
@@ -25,6 +25,12 @@ the SSH hostname for your account:
 * If your account is on our global, US-based system at `www.pythonanywhere.com`, then the SSH hostname is `ssh.pythonanywhere.com`
 * If your account is on our EU-based system at `eu.pythonanywhere.com`, then the SSH hostname is `ssh.eu.pythonanywhere.com`
 
+Note the difference in hostnames for both SSH and MySQL:
+| Hostname  | SSH | MySQL | 
+|--|--|--|
+| Global-US | `ssh.pythonanywhere.com` | *username*`.mysql.pythonanywhere-services.com` |
+| EU | `ssh.eu.pythonanywhere.com` | *username*`.mysql.eu.pythonanywhere-services.com` | 
+
 Armed with that, you can do one of the following:
 
 


### PR DESCRIPTION
I spent 4 hours fiddling with errors and Googling like mad why I could not setup my SSH Tunnel to the external Python Anywhere MySQL service and it was simply an issue that I was missing the `.eu` portion of the hostnames. I hope this PR will add clarification and prevent other users from fumbling around the same problem I had.